### PR TITLE
Tiny optimisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootswatch/3.1.1/cerulean/bootstrap.min.css"/>
 <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css"/>
-<style type="text/css">
+<style>
     body { padding-top: 50px; } /* for the navbar */
     .jumbotron h1 {font-size: 32px; line-height: 40px;}
     .banner-add { text-align: center; }


### PR DESCRIPTION
Browsers do not require you to specify what type your style is, so by removing the type attribute, you save a few bytes. Nothing major
